### PR TITLE
Remove providers from module.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -96,5 +96,3 @@
 * MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-aws-eks/tree/master/LICENSE) for full details.
 */
 
-provider "null" {}
-provider "template" {}


### PR DESCRIPTION
# No explicit providers

## Description

Don't include Terraform providers in the module, as this causes issues when deleting instances of the module. Instead, the root module should specify all providers, and modules inherit them automatically by default.

### Checklist

- [X] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [ ] Docs have been updated using `terraform-docs` per `README.md` instructions
- [ ] I've added my change to CHANGELOG.md
- [ ] Any breaking changes are highlighted above
